### PR TITLE
change line number colors to catppuccin-comment color instead of background

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -112,8 +112,8 @@ read it before opening a new issue about your will.")
                (info-string :foreground ,catppuccin-yellow)
                (lazy-highlight :foreground ,fg2 :background ,bg2)
                (link :foreground ,catppuccin-cyan :underline t)
-               (linum :slant italic :foreground ,catppuccin-fg :background ,catppuccin-bg)
-               (line-number :slant italic :foreground ,catppuccin-fg :background ,catppuccin-bg)
+               (linum :slant italic :foreground ,catppuccin-comment :background ,catppuccin-bg)
+               (line-number :slant italic :foreground ,catppuccin-comment :background ,catppuccin-bg)
                (match :background ,catppuccin-yellow :foreground ,catppuccin-bg)
                (menu :background ,catppuccin-current :inverse-video nil
                      ,@(if catppuccin-alternate-mode-line-and-minibuffer

--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -112,8 +112,8 @@ read it before opening a new issue about your will.")
                (info-string :foreground ,catppuccin-yellow)
                (lazy-highlight :foreground ,fg2 :background ,bg2)
                (link :foreground ,catppuccin-cyan :underline t)
-               (linum :slant italic :foreground ,bg4 :background ,catppuccin-bg)
-               (line-number :slant italic :foreground ,bg4 :background ,catppuccin-bg)
+               (linum :slant italic :foreground ,catppuccin-fg :background ,catppuccin-bg)
+               (line-number :slant italic :foreground ,catppuccin-fg :background ,catppuccin-bg)
                (match :background ,catppuccin-yellow :foreground ,catppuccin-bg)
                (menu :background ,catppuccin-current :inverse-video nil
                      ,@(if catppuccin-alternate-mode-line-and-minibuffer


### PR DESCRIPTION
The line number colors are at the moment set to a background color which makes them essentially invisible, as it is almost the same color as their background.
In this PR I have set them to the catppuccin foreground color so that they are visible. 😸