### PR TITLE
docs: mention that `custom-theme-directory` must be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,21 @@
 
 1. Download repo locally.
 
-2. Add your theme of choice to:
-   `.emacs.d/themes` if you use vanilla emacs or `.doom.d/themes` if you use Doom emacs <i>(If the `themes` folder doesn't exist make a folder with its name)</i>
-3. Install autothemer using either package.el or your choice of package manager to install from MELPA.
+2. Add your theme of choice to either:
+   - `.emacs.d/themes` if you use vanilla Emacs. If the `themes` folder doesn't
+     exist, make a folder with its name. Make sure to set the
+     `custom-theme-directory` variable. Or,
+   - `.doom.d/themes` if you use Doom Emacs.
+3. Install autothemer using either package.el or your choice of package manager
+   to install from MELPA.
 
 ## Using
 In your `.emacs.d` or `.doom.d` add the following lines in `config.el`
-```
+```elisp
 (use-package autothemer
   :ensure t)
 
+(setq custom-theme-directory "~/.emacs.d/themes/")
 (load-theme 'catppuccin-(mocha, macchiato, frappe or latte go here) t)
 ```
 


### PR DESCRIPTION
By default, the value of `custom-theme-directory` in Emacs is "~/.emacs.d". So if a user tried to run the code snippet in the documentation, he would be met with an error saying that "catppuccin" couldn't be loaded.

If we tell the user to install the theme to "~/.emacs.d/themes", then we should also tell him to set `custom-theme-directory` to that value.