### PR TITLE
feat: add highlight-indent-guides

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -998,7 +998,17 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
                (yard-tag-face :inherit font-lock-builtin-face)
                (yard-directive-face :inherit font-lock-builtin-face)
                ;; line-reminder
-               (line-reminder-modified-sign-face :foreground ,ctp-green))))
+               (line-reminder-modified-sign-face :foreground ,ctp-green)
+               ;; highlight-indent-guides
+               ;; (highlight-indent-guides-odd-face :background ,ctp-base)
+               ;; (highlight-indent-guides-even-face :background ,ctp-base)
+               (highlight-indent-guides-character-face :foreground ,ctp-surface0)
+               ;; (highlight-indent-guides-top-odd-face :background ,ctp-base)
+               ;; (highlight-indent-guides-top-even-face :background ,ctp-base)
+               (highlight-indent-guides-top-character-face :foreground ,ctp-pink)
+               ;; (highlight-indent-guides-stack-odd-face :background ,ctp-base)
+               ;; (highlight-indent-guides-stack-even-face :background ,ctp-base)
+               (highlight-indent-guides-stack-character-face :foreground ,ctp-flamingo))))
 
   (apply #'custom-theme-set-faces
          'catppuccin


### PR DESCRIPTION
This PR adds [highlight-indent-guides](https://github.com/DarthFennec/highlight-indent-guides) face definitions. I tried to make it as close as https://github.com/catppuccin/nvim and I come up with `pink` for the active indent and `surface0` for the inactive ones. Suggestions welcome!

![image](https://user-images.githubusercontent.com/57625126/220214488-867502b3-e90a-40c9-8029-3462105044be.png)

