### PR TITLE
feat: use distinct color for current line number

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -296,6 +296,7 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
                (link-unvisited :foreground ,ctp-mauve :underline t)
                (linum :foreground ,ctp-surface1 :background ,ctp-base)
                (line-number :foreground ,ctp-surface1 :background ,ctp-base)
+               (line-number-current-line :inherit line-number :foreground ,ctp-lavender)
                (match :background ,ctp-surface1 :foreground ,ctp-text)
                (menu :background ,ctp-current :inverse-video nil :foreground ,ctp-text)
                (minibuffer-prompt :weight normal :foreground ,ctp-subtext0)
@@ -1008,9 +1009,7 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
                (highlight-indent-guides-top-character-face :foreground ,ctp-pink)
                ;; (highlight-indent-guides-stack-odd-face :background ,ctp-base)
                ;; (highlight-indent-guides-stack-even-face :background ,ctp-base)
-               (highlight-indent-guides-stack-character-face :foreground ,ctp-flamingo)
-               ;; line-number
-               (line-number-current-line :inherit line-number :foreground ,ctp-lavender))))
+               (highlight-indent-guides-stack-character-face :foreground ,ctp-flamingo))))
 
   (apply #'custom-theme-set-faces
          'catppuccin

--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -1008,7 +1008,9 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
                (highlight-indent-guides-top-character-face :foreground ,ctp-pink)
                ;; (highlight-indent-guides-stack-odd-face :background ,ctp-base)
                ;; (highlight-indent-guides-stack-even-face :background ,ctp-base)
-               (highlight-indent-guides-stack-character-face :foreground ,ctp-flamingo))))
+               (highlight-indent-guides-stack-character-face :foreground ,ctp-flamingo)
+               ;; line-number
+               (line-number-current-line :inherit line-number :foreground ,ctp-lavender))))
 
   (apply #'custom-theme-set-faces
          'catppuccin


### PR DESCRIPTION
This PR modifies `line-number-current-line` face so that the current line number has different color than others to make it consistent to https://github.com/catppuccin/nvim. Suggestions welcome!

![image](https://user-images.githubusercontent.com/57625126/220241724-9292ec67-fe5f-4630-a53d-145b982b40b9.png)

Note: IMO it could be improved so that the current line number is left-aligned with 4 character space/template just as the neovim theme (neovim default I guess?), but I couldn't find the variable/function for this 😅

![image](https://user-images.githubusercontent.com/57625126/220240764-a59df038-0096-4973-9999-519c01d9a978.png)