### PR TITLE
Add background for paren match.

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -51,6 +51,11 @@ The theme has to be reloaded after changing anything in this group."
   :type 'number
   :group 'catppuccin)
 
+(defcustom catppuccin-highlight-matches nil
+  "Use background color to make highlighted matches more visible."
+  :type 'boolean
+  :group 'catppuccin)
+
 (defcustom catppuccin-flavor 'mocha
   "The flavor to use for the Catppuccin theme.
 Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
@@ -900,8 +905,9 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
                (rst-level-8 :foreground ,ctp-blue)
                ;; show-paren
                (show-paren-match :foreground ,ctp-pink
-                                 :background ,ctp-surface1
-                                 :weight bold)
+                                 :weight bold
+                                 ,@(when catppuccin-highlight-matches
+                                     (list :background ctp-surface0)))
                (show-paren-match-expression :inherit match)
                (show-paren-mismatch :inherit warning)
                ;; slime

--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -900,6 +900,7 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
                (rst-level-8 :foreground ,ctp-blue)
                ;; show-paren
                (show-paren-match :foreground ,ctp-pink
+                                 :background ,ctp-surface1
                                  :weight bold)
                (show-paren-match-expression :inherit match)
                (show-paren-mismatch :inherit warning)


### PR DESCRIPTION
Request for comment as I'm not sure my taste matches the theme on this one.

The current version of show-paren-match is pretty subtle. Changing the background matches what ef-themes and modus-themes do to make the effect more obvious.

Here's what it looks like:
![image](https://user-images.githubusercontent.com/61418/227753964-45e50a88-f3f1-4456-ada9-27eb6f6f401e.png)
![image](https://user-images.githubusercontent.com/61418/227754004-36723d25-240c-4c17-8ca7-2ab06aa0c0fd.png)



