### PR TITLE
feat: changes trailing-spaces face

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -1080,6 +1080,7 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
                (whitespace-space-before-tab :inherit warning)
                (whitespace-tab :inherit whitespace-newline)
                (whitespace-trailing :inherit trailing-whitespace)
+               (trailing-whitespace :foreground ,ctp-yellow :background ,ctp-yellow)
                ;; yard-mode
                (yard-tag-face :inherit font-lock-builtin-face)
                (yard-directive-face :inherit font-lock-builtin-face)

--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -1080,7 +1080,7 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
                (whitespace-space-before-tab :inherit warning)
                (whitespace-tab :inherit whitespace-newline)
                (whitespace-trailing :inherit trailing-whitespace)
-               (trailing-whitespace :foreground ,ctp-yellow :background ,ctp-yellow)
+               (trailing-whitespace :foreground ,ctp-peach :background ,ctp-peach)
                ;; yard-mode
                (yard-tag-face :inherit font-lock-builtin-face)
                (yard-directive-face :inherit font-lock-builtin-face)


### PR DESCRIPTION

Regarding #98 .

This was also messing with my workflow :)

The way it is catppuccin is showing (only the variable show-trailing-whitespace set to t)
[left terminal / right GUI]
![trailing_opt](https://github.com/catppuccin/emacs/assets/16169950/c731a28d-0b2f-4dc5-a4dc-cb6c1de9bc79)

Applying a background the same color it was (warning):
![trailing_opt2](https://github.com/catppuccin/emacs/assets/16169950/779db589-b5dd-4d73-ad2c-0f951061b996)

And on whitespace-mode:
![whitespace-mode](https://github.com/catppuccin/emacs/assets/16169950/eef7db9a-cad6-4128-9416-900cc946413e)

Problem is there's a color bump with the cursor and it becomes invisible
![color_bump](https://github.com/catppuccin/emacs/assets/16169950/ad60ada1-275f-425d-842e-726c2018a36c)

So according to https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md I peeked the peach color for this:
 
![peach](https://github.com/catppuccin/emacs/assets/16169950/43fa943a-10cf-48ba-80ff-969312d3ad3e)
