### PR TITLE
feat: customization for indent-guide-mode

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -668,6 +668,8 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
                (ido-virtual :foreground ,ctp-sapphire)
                (ido-incomplete-regexp :inherit warning)
                (ido-indicator :foreground ,ctp-text :weight bold)
+               ;; indent-guide
+               (indent-guide-face :foreground ,ctp-surface1)
                ;; ivy
                (ivy-current-match                            :background ,ctp-red :foreground ,ctp-mantle :bold t)
                (ivy-action                                   :background unspecified :foreground ,ctp-lavender)


### PR DESCRIPTION
Hi!

I saw the theme has `highlight-indent-guides` faces, I was tweaking with it and nothing happened.

Then I remember I dropped highlight-indent-guides in favor of the `indent-guide-mode`, it is simpler (only one face), but works with functions with blank lines (major problem with the cool `highlight-indent-guides`), like the first image.

Since it is only one line (the current level you're in), surface0 was a little bit too shady, almost difficult to see. I then set surface1 and tested on all variants. 

Mocha:
![image](https://github.com/catppuccin/emacs/assets/16169950/277f53eb-d014-46b4-8ac9-b60b8f82bcaf)

Macchiato:
![Captura de Tela 2023-06-03 às 01 40 58](https://github.com/catppuccin/emacs/assets/16169950/a679ad80-1642-487e-9156-8db255650f1c)

Frappe:
![Captura de Tela 2023-06-03 às 01 38 58](https://github.com/catppuccin/emacs/assets/16169950/681d0e79-3abd-4805-84a0-795d49ca6fea)

Latte:
![image](https://github.com/catppuccin/emacs/assets/16169950/6d2215d8-331e-416f-bb61-5b313ee10394)

Do you think it's good?


