### PR TITLE
feat: adds customization to popup.el tooltip

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -941,6 +941,8 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
                (outline-6 :foreground ,ctp-blue)
                ;; perspective
                (persp-selected-face :weight bold :foreground ,ctp-pink)
+               ;; popup
+               (popup-tip-face :background ,ctp-surface0 :foreground ,ctp-text)
                ;; rainbow-delimiters
                (rainbow-delimiters-depth-1-face :foreground ,ctp-red)
                (rainbow-delimiters-depth-2-face :foreground ,ctp-peach)
@@ -1080,7 +1082,7 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
                (treemacs-tags-face :foreground ,ctp-text)
                (treemacs-term-node-face :foreground ,ctp-blue)
                (treemacs-window-background-face :background ,ctp-base)
-               ;;treemacs-nerd-icons
+               ;; treemacs-nerd-icons
                (treemacs-nerd-icons-root-face :foreground ,ctp-blue)
                (treemacs-nerd-icons-file-face :foreground , ctp-blue)
                ;; tree-sitter


### PR DESCRIPTION
Hello again good people from Catppuccin! 

I use a cool package named `vc-msg` (https://github.com/redguardtoo/vc-msg), it uses `popup.el` (https://github.com/auto-complete/popup-el) to display tooltip messages with the git content regarding the current line.

It defaults to this style:
<img width="579" alt="image" src="https://github.com/catppuccin/emacs/assets/16169950/4efca55e-2cb2-44ce-a725-21e14056dcf0">

And I am proposing this:
<img width="565" alt="image" src="https://github.com/catppuccin/emacs/assets/16169950/49cd277a-d329-4f34-8dfb-14ee111efc62">

Shouts to my typo on the screenshot, lol.
