### PR TITLE
feat: add a convenience function to load a new flavor

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -262,11 +262,11 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
 
 If called non-interactively, the FLAVOR must be one of 'frappe, 'latte, 'macchiato, or 'mocha."
   (interactive
-   (list (make-symbol (completing-read
-                       "Choose a catppuccin theme flavor: "
-                       '(frappe latte macchiato mocha)
-                       nil   ;; predicate
-                       t)))) ;; require-match
+   (list (intern (completing-read
+                  "Choose a catppuccin theme flavor: "
+                  '(frappe latte macchiato mocha)
+                  nil   ;; predicate
+                  t)))) ;; require-match
     (setq catppuccin-flavor flavor)
     (catppuccin-reload)
     (message "Catppuccin flavor now %s" flavor))

--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -257,6 +257,20 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
   (disable-theme 'catppuccin)
   (load-theme 'catppuccin t))
 
+(defun catppuccin-load-flavor (flavor)
+  "Set the desired FLAVOR or choose one from a list if called interactively.
+
+If called non-interactively, the FLAVOR must be one of 'frappe, 'latte, 'macchiato, or 'mocha."
+  (interactive
+   (list (make-symbol (completing-read
+                       "Choose a catppuccin theme flavor: "
+                       '(frappe latte macchiato mocha)
+                       nil   ;; predicate
+                       t)))) ;; require-match
+    (setq catppuccin-flavor flavor)
+    (catppuccin-reload)
+    (message "Catppuccin flavor now %s" flavor))
+
 (defun catppuccin-set-color (color value &optional flavor)
   "Set the COLOR of FLAVOR or the current flavor to VALUE."
   (interactive "SChange color: \nsSet %s to: ")


### PR DESCRIPTION
I'm a catppuccin newbie and I found myself forgetting two things:
1. The names of the different flavors
2. The "correct" way to change flavors

So I added this function to my personal helper functions to overcome those. I thought it might be helpful to others as well, which resulted in this PR.

This adds a convenience function (`catppuccin-load-flavor`) that allows the user to either pass a flavor directly to the function, or call it interactively and choose from a list of available flavors.

## Usage

1. Call it directly and specify which flavor you want.

    ```emacs
    (catppuccin-load-flavor 'latte)
    ```

2. Call it interactively and choose from the list of options.

    ```emacs
    M-x catppuccin-load-flavor
    ```

## In action


https://github.com/catppuccin/emacs/assets/385726/93556ca2-4f06-4252-a1b8-07a099596b70

