### PR TITLE
Fix diff-hl faces

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -435,9 +435,9 @@ If called non-interactively, the FLAVOR must be one of 'frappe, 'latte, 'macchia
                (completions-common-part :foreground ,ctp-sky)
                (completions-first-difference :foreground ,ctp-text)
                ;; diff-hl
-               (diff-hl-change :foreground ,ctp-blue :background ,ctp-blue)
-               (diff-hl-delete :foreground ,ctp-red :background ,ctp-red)
-               (diff-hl-insert :foreground ,ctp-green :background ,ctp-green)
+               (diff-hl-change :inherit fringe :foreground ,ctp-blue)
+               (diff-hl-delete :inherit fringe :foreground ,ctp-red)
+               (diff-hl-insert :inherit fringe :foreground ,ctp-green)
                ;; diff-refine
                (diff-refine-removed :weight bold)
                (diff-refine-added :weight bold)


### PR DESCRIPTION
## Before

<img width="271" alt="Screenshot 2024-03-25 at 10 40 52" src="https://github.com/catppuccin/emacs/assets/6035856/066d829c-9827-4c69-9f28-7b4916128c84">

## After

<img width="253" alt="Screenshot 2024-03-25 at 10 40 05" src="https://github.com/catppuccin/emacs/assets/6035856/3350812d-4c2d-457c-901f-b94c819f31a0">

## Note

About `:inherit fringe`, I've been using it without any issues in [`nimbus-theme`](https://github.com/mrcnski/nimbus-theme) for some years. It just makes sure that the background matches the fringe background. Not relevant here, but in nimbus-theme it also makes sure that any other properties (like boldness) get cleared.