### PR TITLE
Enable byte-compile for faster startup

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -1,4 +1,4 @@
-;;; catppuccin-theme.el --- Catppuccin for Emacs - 🍄 Soothing pastel theme for Emacs -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; catppuccin-theme.el --- Catppuccin for Emacs - 🍄 Soothing pastel theme for Emacs -*- lexical-binding: t; no-byte-compile: nil; -*-
 
 ;; Copyright 2022-present, All rights reserved
 ;;


### PR DESCRIPTION
This PR should fix the issue [127](https://github.com/catppuccin/emacs/issues/127)
I've been using this byte-compiled for a long time now without any issues.

Results on my machine (See the load times):
Without byte-compile:
<img width="520" alt="Screenshot 2024-04-23 at 16 22 16" src="https://github.com/catppuccin/emacs/assets/6806889/00578704-7ec1-47ea-904b-21af2c5c5702">

With byte-compile:
<img width="751" alt="Screenshot 2024-04-23 at 16 23 10" src="https://github.com/catppuccin/emacs/assets/6806889/563dd1a3-20a4-4e37-ab9e-19f35ba4c3b7">
