### PR TITLE
docs: performance hint for doom emacs users

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Doom users must call `(load-theme 'catppuccin t t)` before being able to call an
 >[!NOTE]
 >If you are using emacsclient and rustic, you should add `(add-hook 'server-after-make-frame-hook #'catppuccin-reload)` to your config to avoid [this issue](https://github.com/catppuccin/emacs/issues/121)
 
+>[!NOTE]
+>If you are using doom emacs and want to customize the `catppuccin-flavor`, calling `(catppuccin-reload)` after `load-theme` may slow emacs startup time. To change the flavor, it is sufficient to `setq` the desired flavor before loading the theme. Then, calling `(catppuccin-reload)` can be omitted because catppuccin will be loaded with the desired flavor directly.
+
 ## 💝 Thanks to
 
 - [Nyx](https://github.com/nyxkrage)


### PR DESCRIPTION
This commit adds a hint to the README for doom emacs users.

Customizing the flavor of cattpuccin in doom emacs as suggested in the README:
```lisp
(load-theme 'catppuccin t t)
(setq catppuccin-flavor 'frappe) ;; or 'latte, 'macchiato, or 'mocha
(catppuccin-reload)
```
increases the startup time of doom emacs significantly (likely because catppuccin is loaded twice).
I noticed that setting the flavor before loading the theme:
```lisp
(setq catppuccin-flavor 'frappe) ;; or 'latte, 'macchiato, or 'mocha
(load-theme 'catppuccin t t)
```
works and so the call to `(catppuccin-reload)` can be omitted, yielding fast startup times again.

I added a respective hint for doom users to the README.