### PR TITLE
chore: update .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,4 +3,4 @@
 #     git blame --ignore-revs-file .git-blame-ignore-revs
 
 # chore: reformat
-648e6815f576326b38cbd542ebd0823a36012e52
+a1fcef417aa7bd5d3b7c31429d142579e45d8ea9


### PR DESCRIPTION
Commit hash got mangled in github's merge
