### PR TITLE
feat: style smerge faces

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -409,6 +409,8 @@ or `mocha'."
          (diff-hl-insert :inherit fringe :foreground ,ctp-green)
 
          ;; diff-mode
+         (diff-header :foreground ,ctp-blue)
+         (diff-hunk-header :foreground ,ctp-text :background ,ctp-surface2)
          (diff-added :background ,(catppuccin-darken ctp-green 60))
          (diff-removed :background ,(catppuccin-darken ctp-red 60))
          (diff-indicator-added :foreground ,ctp-green)
@@ -854,8 +856,6 @@ or `mocha'."
          (magit-diffstat-added :foreground ,ctp-green)
          (magit-diffstat-removed :foreground ,ctp-red)
          (magit-hash :foreground ,ctp-subtext0)
-         (diff-header :foreground ,ctp-blue)
-         (diff-hunk-header :foreground ,ctp-text :background ,ctp-surface2)
          (magit-diff-hunk-heading :inherit diff-hunk-header)
          (magit-diff-hunk-heading-highlight :inherit diff-hunk-header :weight bold)
          (magit-log-author :foreground ,ctp-subtext0)

--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -417,6 +417,8 @@ or `mocha'."
          (diff-indicator-removed :foreground ,ctp-red)
          (diff-refine-added :background ,(catppuccin-darken ctp-green 40))
          (diff-refine-removed :background ,(catppuccin-darken ctp-red 40))
+         (diff-refine-changed :background ,ctp-yellow
+           :foreground ,ctp-base)
 
          ;; eshell
          (eshell-ls-archive :foreground ,ctp-mauve)
@@ -1100,6 +1102,7 @@ or `mocha'."
            :background nil)
          (smerge-refined-removed :inherit diff-refine-removed
            :background nil)
+         (smerge-base :inherit diff-refine-changed :background nil)
 
          ;; swiper
          ;;(swiper-line-face :inherit swiper-match-face1)

--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -1093,6 +1093,14 @@ or `mocha'."
          ;; slime
          (slime-repl-inputed-output-face :foreground ,ctp-mauve)
 
+         ;; smerge
+         (smerge-lower :inherit diff-added :background nil)
+         (smerge-upper :inherit diff-removed :background nil)
+         (smerge-refined-added :inherit diff-refine-added
+           :background nil)
+         (smerge-refined-removed :inherit diff-refine-removed
+           :background nil)
+
          ;; swiper
          ;;(swiper-line-face :inherit swiper-match-face1)
          ;;(swiper-line-face-1 :inherit swiper-match-face1)


### PR DESCRIPTION
Before/after:
![smergery](https://github.com/user-attachments/assets/ac916a35-0f07-4013-a338-eb9e77fe0c0f)

Kind of weird in this picture since it's viewing a diff with unsolved git conflicts.