### PR TITLE
fix: read catppuccin-definitions.el in temp buffer instead of visiting

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -128,10 +128,9 @@ The colors used will correspond to those in COLORS."
 
 (when load-file-name
   ;; load the flavor definitions
-  (with-current-buffer (find-file-noselect
-                         (concat (file-name-directory load-file-name)
-                           "catppuccin-definitions.el"))
-    (goto-char (point-min))
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name "catppuccin-definitions.el"
+                            (file-name-directory load-file-name)))
     (setq catppuccin-flavor-alist (read (current-buffer))))
 
   ;; define flavors


### PR DESCRIPTION
The `catppuccin-definitions.el` file is currently loaded using the `find-file-noselect` function, which is inappropriate for the following reasons:
- It creates a file-visiting buffer that distracts the user and clutters their post-init Emacs state.
- It runs additional code to initialize buffer major mode and so on, which are unnecessary.

This PR fixes the code to use a temporary buffer to read the contents of `catppuccin-definitions.el` and pass the contents to the lisp reader, avoiding the aforementioned issues.