### PR TITLE
feat: color org-mode-line-clock-overrun

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -1089,6 +1089,7 @@ If called non-interactively, the FLAVOR must be one of 'frappe, 'latte, 'macchia
          (org-level-8 :weight normal :foreground ,ctp-maroon)
          (org-link :inherit link)
          (org-meta-line :inherit font-lock-comment-face)
+         (org-mode-line-clock-overrun :inherit mode-line :foreground ,ctp-red)
          (org-priority :foreground ,ctp-yellow)
          (org-quote :inherit markdown-blockquote-face)
          (org-scheduled :foreground ,ctp-green)


### PR DESCRIPTION
### Old:
![image](https://github.com/user-attachments/assets/2012c706-7d44-4220-8e8b-9b53b05e8fda)

<!--Provide a screenshot of the original issue if applicable:
  ![original-screenshot-here](Please)
-->

### New:
![image](https://github.com/user-attachments/assets/e8471bb2-6ff1-4609-ad37-49a1e5397ea1)
<!--Provide a screenshot of your changes if applicable:
  ![original-screenshot-here](Please)
-->

I chose to color the foreground rather than the background since I think that looks cleaner, but I'm open to either :slightly_smiling_face:.