### PR TITLE
Copy `markdown-blockquote-face` definition to `org-quote`

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -1084,7 +1084,9 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          (org-meta-line :inherit font-lock-comment-face)
          (org-mode-line-clock-overrun :inherit mode-line :foreground ,ctp-red)
          (org-priority :foreground ,ctp-yellow)
-         (org-quote :inherit markdown-blockquote-face)
+         (org-quote :extend t :background ,ctp-mantle
+           :foreground ,ctp-green
+           ,@(when catppuccin-italic-blockquotes '(:slant italic)))
          (org-scheduled :foreground ,ctp-green)
          (org-scheduled-previously :foreground ,ctp-teal)
          (org-scheduled-today :foreground ,ctp-green :weight bold)

--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -939,7 +939,6 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          (magit-process-ok :foreground ,ctp-green :weight bold)
 
          ;; markdown
-         (markdown-blockquote-face :foreground ,ctp-green)
          (markdown-blockquote-face :extend t :background ,ctp-mantle
            :foreground ,ctp-green
            ,@(when catppuccin-italic-blockquotes '(:slant italic)))


### PR DESCRIPTION
### Old:
![image](https://github.com/user-attachments/assets/6bb4f8f3-7693-4a9f-9ba3-555cd88d8f99)
(before `markdown-mode` is loaded)
<!--Provide a screenshot of the original issue if applicable:
  ![original-screenshot-here](Please)
-->

### New:
![image](https://github.com/user-attachments/assets/e6a1e441-81e3-40e5-b516-3cec88476e52)

<!--Provide a screenshot of your changes if applicable:
  ![original-screenshot-here](Please)
-->

`markdown-mode` may not be loaded by the time Org is used, which results in the
`org-quote` face being unstyled since `markdown-blockquote-face` is not yet defined.

I also took the opportunity to remove a seemingly-duplicate entry for `markdown-blockquote-face` :shrug:.

Probably fixes #123 