### PR TITLE
fix: use unspecified over nil in smerge faces

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -1179,13 +1179,13 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          (slime-repl-inputed-output-face :foreground ,ctp-mauve)
 
          ;; smerge
-         (smerge-lower :inherit diff-added :background nil)
-         (smerge-upper :inherit diff-removed :background nil)
+         (smerge-lower :inherit diff-added :background unspecified)
+         (smerge-upper :inherit diff-removed :background unspecified)
          (smerge-refined-added :inherit diff-refine-added
-           :background nil)
+           :background unspecified)
          (smerge-refined-removed :inherit diff-refine-removed
-           :background nil)
-         (smerge-base :inherit diff-refine-changed :background nil)
+           :background unspecified)
+         (smerge-base :inherit diff-refine-changed :background unspecified)
 
          ;; swiper
          ;;(swiper-line-face :inherit swiper-match-face-1)


### PR DESCRIPTION
Updates the smerge faces to use unspecified rather than nil to avoid warnings in the emacs message buffer

### Old:

<!--Provide a screenshot of the original issue if applicable:
https://media.discordapp.net/attachments/764719568467001347/1294838739180458006/3236D1F9-9A88-4717-945F-25C150F8545E.png?ex=670c780c&is=670b268c&hm=897881dc110e366070b34aefd826b9ffe469f48443c150ae6a57763380d39373&=&format=webp&quality=lossless
-->

### New:

<!--Provide a screenshot of your changes if applicable:
  ![original-screenshot-here](Please)
-->
