### PR TITLE
feat: style font-lock-property-name-face

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -413,6 +413,7 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          (font-lock-number-face :foreground ,ctp-peach)
          (font-lock-operator-face :foreground ,ctp-sky)
          (font-lock-preprocessor-face :foreground ,ctp-yellow)
+         (font-lock-property-name-face :foreground ,ctp-blue)
          (font-lock-reference-face :inherit font-lock-constant-face) ; obsolete
          (font-lock-regexp-grouping-backslash :foreground ,ctp-red)
          (font-lock-regexp-grouping-construct :foreground ,ctp-red)


### PR DESCRIPTION
### Old:

![08:02 AM 10-12-2024](https://github.com/user-attachments/assets/bd269dbc-c67f-4609-a88c-0636b8825d62)

### New:

![08:10 AM 10-12-2024](https://github.com/user-attachments/assets/d9ed9998-f236-4497-8679-20f4b8182e6b)

See: https://github.com/catppuccin/emacs/issues/189

Not all major modes use this face, but, as shown in the example above, at least json-ts-mode does.

EDIT: well, it uses font-lock-property-use-face, but that one inherits from font-lock-property-name-face