### PR TITLE
feat: style flymake faces

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -699,6 +699,11 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          (enh-ruby-regexp-delimiter-face :foreground ,ctp-yellow)
          (enh-ruby-string-delimiter-face :foreground ,ctp-yellow)
 
+         ;; flymake
+         (flymake-error :underline (:style wave :color ,ctp-red))
+         (flymake-note :underline (:style wave :color ,ctp-green))
+         (flymake-warning :underline (:style wave :color ,ctp-yellow))
+
          ;; flyspell
          (flyspell-duplicate :underline (:style wave :color ,ctp-teal))
          (flyspell-incorrect :underline (:style wave :color ,ctp-maroon))


### PR DESCRIPTION
Currently, the in-buffer faces for Flymake aren't customized. This makes them incosistent with the ones used for echo messages, i.e. `flymake-note-echo`, since it inherits from `compilation-info`, which in turn inherits from `success`.

### Old:

![07:59 PM 10-12-2024](https://github.com/user-attachments/assets/bb0df45d-1ca5-4aab-9bfb-f046f7f6d5da)

### New:

![08:00 PM 10-12-2024](https://github.com/user-attachments/assets/0ef59c11-21a8-45bc-a0f0-d3f4522cf55d)

For more details, see #203

I can close this PR is this was an intentional design decision.

Closes #203