### PR TITLE
Update adoc faces

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -427,7 +427,7 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
 
          ;; adoc-mode
          (adoc-anchor-face :foreground ,ctp-blue)
-         (adoc-code-face :inherit ,ctp-text)
+         (adoc-code-face :foreground ,ctp-text)
          (adoc-command-face :foreground ,ctp-yellow)
          (adoc-emphasis-face :inherit bold)
          (adoc-internal-reference-face :foreground ,ctp-yellow :underline t)

--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -430,10 +430,11 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          (adoc-code-face :foreground ,ctp-text)
          (adoc-command-face :foreground ,ctp-yellow)
          (adoc-emphasis-face :inherit bold)
-         (adoc-internal-reference-face :foreground ,ctp-yellow :underline t)
+         (adoc-internal-reference-face :foreground ,ctp-green)
          (adoc-list-face :foreground ,ctp-text)
-         (adoc-meta-face :foreground ,ctp-yellow)
-         (adoc-meta-hide-face :foreground ,ctp-yellow)
+         (adoc-meta-face :inherit font-lock-comment-face)
+         (adoc-meta-hide-face :inherit font-lock-comment-face)
+         (adoc-reference-face :inherit link)
          (adoc-secondary-text-face :foreground ,ctp-yellow)
          (adoc-title-0-face :foreground ,ctp-red
            ,@(when catppuccin-enlarge-headings


### PR DESCRIPTION
After using the colors for a bit I've identified a few small improvements and now they look better IMO (and are more consistent with Markdown)

### Old:

<img width="741" alt="image" src="https://github.com/user-attachments/assets/96ce8d5a-5a3f-45e4-ae01-dbb5e8892c53" />


### New:

<img width="816" alt="image" src="https://github.com/user-attachments/assets/89d08d45-35b5-4512-a564-fb429bc02a8c" />

