### PR TITLE
fix: Italics shown as underlined

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -302,6 +302,7 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          ;; default / basic faces
          (cursor :background ,ctp-rosewater)
          (default :background ,ctp-base :foreground ,ctp-text)
+         (italic :slant italic)
          (default-italic :slant italic)
          (hl-todo :foreground ,ctp-peach)
          (error :foreground ,ctp-red)


### PR DESCRIPTION
Fixed #128 "Italics shown as underlined in doom emacs 29 pgtk"

![20250302_19h06m36s_grim](https://github.com/user-attachments/assets/5c51ea4e-fda3-46ae-957b-742ff7c70c59)



