### PR TITLE
Add eglot-supplements faces

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -683,6 +683,10 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          (fg:erc-color-face14 :foreground ,ctp-overlay2)
          (fg:erc-color-face15 :foreground ,ctp-text)
 
+         ;; eglot-supplements
+         (eglot-cthier-recursive-mark-face :foreground ,ctp-red)
+         (eglot-marocc-occurence-text :foreground ,ctp-green)
+
          ;; enh-ruby
          (enh-ruby-heredoc-delimiter-face :foreground ,ctp-yellow)
          (enh-ruby-op-face :inherit haskell-operator-face)


### PR DESCRIPTION
[eglot-supplements](https://codeberg.org/harald/eglot-supplements) is a package that additional Language Server Protocol specifications to Eglot.

Most of the faces there are implemented using ~inheritage~ inheritance, except for these two I added to the commit.

### Old:

<details>

![08:32 AM 07-03-2025](https://github.com/user-attachments/assets/26df17f3-0c57-430b-8b45-268cdaef48fa)
</details>

### New:

<details>

![08:34 AM 07-03-2025](https://github.com/user-attachments/assets/e1ba2d7c-9227-48cd-b310-8462a6436c6e)
</details>