### PR TITLE
feat: style completion-preview-exact

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -465,6 +465,8 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          (completions-annotations :inherit font-lock-comment-face)
          (completions-common-part :foreground ,ctp-sky)
          (completions-first-difference :foreground ,ctp-text)
+         ;; completion-preview
+         (completion-preview-exact :underline ,ctp-red :inherit completion-preview-common)
 
          ;; diff-hl
          (diff-hl-change :background ,ctp-blue


### PR DESCRIPTION
Most of the faces in `completion-preview` already look good with Catppuccin (due to ~inheritage~ inheritance), except for this one.

### Old:

<details>

![10:01 AM 09-03-2025](https://github.com/user-attachments/assets/92a3760b-b44b-4d78-be28-4b73280908d8)
</details>

### New:

<details>

![11:33 AM 09-03-2025](https://github.com/user-attachments/assets/2fd5697f-95ef-459f-b9df-f2bd4d5fa115)
</details>

### Points of discussion

Maybe making it inherit from `match` makes more sense? Here is the look:

<details>

![11:36 AM 09-03-2025](https://github.com/user-attachments/assets/58cb598e-5ece-447a-8145-c10b4471ce42)
</details>

Let me know what you think. From a first impression I kind of like it, but maybe it could get annoying after some time.