### PR TITLE
Emacs Catppuccin theme powerline foreground/background

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -765,10 +765,10 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          (helm-visible-mark :foreground ,ctp-red)
 
          ;; powerline
-         (powerline-active1 :background ,ctp-peach :foreground ,ctp-surface0)
-         (powerline-active2 :background ,ctp-rosewater :foreground ,ctp-surface0)
-         (powerline-inactive1 :background ,ctp-surface2 :foreground ,ctp-text)
-         (powerline-inactive2 :background ,ctp-overlay2 :foreground ,ctp-subtext1)
+         (powerline-active1 :foreground ,ctp-peach :background ,ctp-surface0)
+         (powerline-active2 :foreground ,ctp-rosewater :background ,ctp-surface0)
+         (powerline-inactive1 :foreground ,ctp-text :background ,ctp-surface2)
+         (powerline-inactive2 :foreground ,ctp-subtext1 :background ,ctp-overlay2)
 
          ;; consult
          (consult-async-split :foreground ,ctp-mauve)


### PR DESCRIPTION
Corrected powerline active colors by swapping foreground and background values for better visibility.

Fixed #226 

### Old:
![image](https://github.com/user-attachments/assets/15a699c0-2277-411c-92b8-06e4f28156fa)


### New:
![image](https://github.com/user-attachments/assets/18262dd7-775b-4471-a402-3c1af5dfee28)
