### PR TITLE
Option for darker line numbers

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -70,6 +70,11 @@ The theme has to be reloaded after changing anything in this group."
   :type 'boolean
   :group 'catppuccin)
 
+(defcustom catppuccin-dark-line-numbers-background nil
+  "Use the mantle background color for line numbers to make them stand out more."
+  :type 'boolean
+  :group 'catppuccin)
+
 (defcustom catppuccin-italic-variables nil
   "Use :slant italic for variables."
   :type 'boolean
@@ -309,7 +314,10 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
           (catppuccin-quantize-color
             (if (eq catppuccin-flavor 'latte)
               (catppuccin-darken (catppuccin-color 'base) 12)
-              (catppuccin-lighten (catppuccin-color 'base) 17))))))
+              (catppuccin-lighten (catppuccin-color 'base) 17))))
+        (ctp-linum (if catppuccin-dark-line-numbers-background
+                     (catppuccin-color 'mantle)
+                     (catppuccin-color 'base)))))
     (faces
       '(
          ;; default / basic faces
@@ -334,9 +342,9 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          (link :foreground ,ctp-lavender :underline t)
          (link-unvisited :foreground ,ctp-blue :underline t)
          (linum :inherit default :foreground ,ctp-surface1
-           :background ,ctp-base)
+           :background ,ctp-linum)
          (line-number :inherit default :foreground ,ctp-surface1
-           :background ,ctp-base)
+           :background ,ctp-linum)
          (line-number-current-line :inherit line-number
            :foreground ,ctp-lavender)
          (match :background ,ctp-red :foreground ,ctp-mantle)


### PR DESCRIPTION
### Old:

<img width="1033" height="219" alt="Screenshot 2025-09-10 at 16 04 09" src="https://github.com/user-attachments/assets/875f3c88-8190-49f8-9be8-1b85c99ad128" />

### New:

<img width="1033" height="219" alt="Screenshot 2025-09-10 at 16 04 36" src="https://github.com/user-attachments/assets/ebb78fb0-97ee-4a76-906e-1c0005f4183f" />


---

Add a `defcustom` to make line numbers darker by using the `mantle` color rather than the `base` color.  Only `linum` and `line-number` has been changed; mode specific line number faces were all already using something other than the base color.

This is a personal preference of mine, so I thought I'd add it as an option.  I've left the default to be `nil`, so there is no change in default behavior.